### PR TITLE
scanning_drift_corr v1.0.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "scanning_drift_corr" %}
-{% set version = "1.0.0" %}
+{% set version = "1.0.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 07aa7e271ab423644fc577c7655e6030ce7833c6c10558b5774149f7d91e3668
+  sha256: 3506995a12a692235861f4c422a3fc57af15a629c4ebddf75ad6cc3bc1d27f80
 
 build:
   number: 0
@@ -16,10 +16,10 @@ build:
 
 requirements:
   host:
-    - python >=3.7
+    - python >=3.8
     - pip
   run:
-    - python >=3.7
+    - python >=3.8
     - numpy
     - matplotlib-base
     - scipy

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -12,7 +12,7 @@ if __name__ == '__main__':
     im2[5,2] = 10
     im2[2,4] = 10
 
-    sm = sdc.SPmerge01linear(scanAngles, im1, im2)
-    sm = sdc.SPmerge02(sm, 8, 8)
+    sm = sdc.SPmerge01linear(scanAngles, im1, im2, parallel=True)
+    sm = sdc.SPmerge02(sm, 8, 8, parallel=False)
     imageFinal, signalArray, densityArray = sdc.SPmerge03(sm)
 


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

This version fixes the issue in Windows and macOS, so now the package should be able to build on Windows and macOS.